### PR TITLE
- Fixed some incompatibilities with ObamiumStuff (and bugs, technical…

### DIFF
--- a/MuckArrows/CHANGELOG.md
+++ b/MuckArrows/CHANGELOG.md
@@ -4,3 +4,6 @@
 # v1.1.0
 - Sprites for Ruby, Obamium, and Chunkium arrows added
 - Chunkium arrows are now made using Oak Wood
+
+# v1.2.0
+- Fixed a bug with ObamiumStuff (and possibly other mods) that caused you to be unable to move on loading a world

--- a/MuckArrows/CreateRecipesPatch.cs
+++ b/MuckArrows/CreateRecipesPatch.cs
@@ -40,7 +40,10 @@ public class CreateRecipesPatch
 			NewArrow(arrowFlint, "Chunkium Arrow", "how do these even fly?", Plugin.ChunkiumArrowDamage, 4, Resources.ChunkiumArrowSprite, Resources.ChunkiumArrowTexture, Plugin.CanCraftChunkiumArrows, new() { amount = 2, item = oakWood }, new() { amount = 1, item = chunkiumBar } ),
 		};
 
-		int id = ItemManager.Instance.allScriptableItems.Length;
+		// The game assigns IDs by the index in allScriptableItems. However, this array doesn't really seem to be used much.
+		// Additionally, some mods use that array for assigning IDs. They may use ItemManager.Instance.allItems.Count as the next ID for example (perfectly valid though)
+		// We'll just grab the largest ID and start from there.
+		int id = ItemManager.Instance.allItems.Keys.DefaultIfEmpty(0).Max() + 1;
 		foreach (var arrow in newArrows)
 		{
 			arrow.id = id++;

--- a/MuckArrows/MuckArrows.csproj
+++ b/MuckArrows/MuckArrows.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MuckArrows</AssemblyName>
     <Description>A plugin which adds various arrows, like Stone, Ruby, Chunkium, Obamium. Allows modifying arrow damage.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 	  <Nullable>enable</Nullable>

--- a/MuckArrows/Plugin.cs
+++ b/MuckArrows/Plugin.cs
@@ -4,7 +4,7 @@ using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
 
-[BepInPlugin("MuckArrows.MichMcb", "Muck Arrows", "1.1.0")]
+[BepInPlugin("MuckArrows.MichMcb", "Muck Arrows", "1.2.0")]
 public class Plugin : BaseUnityPlugin
 {
 	public static ManualLogSource Log = null!;

--- a/MuckArrows/manifest.json
+++ b/MuckArrows/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "MuckArrows",
-	"version_number": "1.1.0",
+	"version_number": "1.2.0",
 	"website_url": "https://github.com/Michmcb/MuckMods",
 	"description": "A plugin which adds various arrows, like Stone, Ruby, Chunkium, Obamium.",
 	"dependencies": ["BepInEx-BepInExPack_Muck-5.4.1101"]

--- a/MuckCharcoal/CHANGELOG.md
+++ b/MuckCharcoal/CHANGELOG.md
@@ -7,3 +7,6 @@
 # v1.2.0
 - Fixed not correctly instantiating the ItemFuel component to eliminate a warning (not sure if that was causing any bugs)
 - Fixed version number
+
+# v1.3.0
+- Fixed a bug with ObamiumStuff (and possibly other mods) that caused you to be unable to move on loading a world

--- a/MuckCharcoal/CreateRecipesPatch.cs
+++ b/MuckCharcoal/CreateRecipesPatch.cs
@@ -70,7 +70,7 @@ public class CreateRecipesPatch
 		charcoal.fuel.currentUses = Plugin.MaxUses;
 		charcoal.fuel.name = coal.name;
 		
-		charcoal.id = ItemManager.Instance.allScriptableItems.Length;
+		charcoal.id = ItemManager.Instance.allItems.Keys.DefaultIfEmpty(0).Max() + 1;
 		ItemManager.Instance.allItems.Add(charcoal.id, charcoal);
 		Plugin.Log.LogItemCreated(charcoal);
 		ItemManager.Instance.allScriptableItems = ItemManager.Instance.allScriptableItems.Concat(new InventoryItem[1] { charcoal }).ToArray();

--- a/MuckCharcoal/MuckCharcoal.csproj
+++ b/MuckCharcoal/MuckCharcoal.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MuckCharcoal</AssemblyName>
     <Description>A simple plugin which adds Charcoal. Wood can be burned in a Furnace to produce Charcoal, which functions similarly to coal. The wood which can be turned into charcoal, how long it takes to create charcoal, and how many items charcoal smelts can be confiugred.</Description>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 	  <Nullable>enable</Nullable>

--- a/MuckCharcoal/Plugin.cs
+++ b/MuckCharcoal/Plugin.cs
@@ -5,7 +5,7 @@ using BepInEx.Logging;
 using HarmonyLib;
 using System;
 
-[BepInPlugin("MuckCharcoal.MichMcb", "Muck Charcoal", "1.2.0")]
+[BepInPlugin("MuckCharcoal.MichMcb", "Muck Charcoal", "1.3.0")]
 public class Plugin : BaseUnityPlugin
 {
 	public static ManualLogSource Log = null!;

--- a/MuckCharcoal/manifest.json
+++ b/MuckCharcoal/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "MuckCharcoal",
-	"version_number": "1.2.0",
+	"version_number": "1.3.0",
 	"website_url": "https://github.com/Michmcb/MuckMods",
 	"description": "Adds Charcoal. Wood can be burned in a Furnace to produce Charcoal, which functions similarly to coal. The wood which can be turned into charcoal, how long it takes to create charcoal, and how many items charcoal smelts can be confiugred.",
 	"dependencies": ["BepInEx-BepInExPack_Muck-5.4.1101"]

--- a/MuckFoods/CHANGELOG.md
+++ b/MuckFoods/CHANGELOG.md
@@ -17,3 +17,6 @@
 
 # v1.4.0
 - Fixed a bug that caused Cauldrons to stop cooking when 6 Toasted Mushrooms/Baked Apples were in the output slot
+
+# v1.5.0
+- Fixed a bug with ObamiumStuff (and possibly other mods) that caused you to be unable to move on loading a world

--- a/MuckFoods/CreateRecipesPatch.cs
+++ b/MuckFoods/CreateRecipesPatch.cs
@@ -148,10 +148,10 @@ public class CreateRecipesPatch
 		applePie.sprite = Resources.PieAppleSprite;
 		meatPie.sprite = Resources.PieMeatSprite;
 
-		// Now we assign IDs to all the newly created items
-		// The way IDs work is basically Muck has the array "allScriptableItems", and IDs are assigned based on index.
-		// So we loop over our new items in order and assign them IDs, add them to the dictionary, then concat it into the array
-		int id = ItemManager.Instance.allScriptableItems.Length;
+		// The game assigns IDs by the index in allScriptableItems. However, this array doesn't really seem to be used much.
+		// Additionally, some mods use that array for assigning IDs. They may use ItemManager.Instance.allItems.Count as the next ID for example (perfectly valid though)
+		// We'll just grab the largest ID and start from there.
+		int id = ItemManager.Instance.allItems.Keys.DefaultIfEmpty(0).Max() + 1;
 		foreach (var item in newItems)
 		{
 			item.id = id++;

--- a/MuckFoods/MuckFoods.csproj
+++ b/MuckFoods/MuckFoods.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MuckFoods</AssemblyName>
     <Description>Adds a wide variety of foods which can be cooked by combining various existing ingredients in a Cauldron. This also decreases the effectiveness of some vanilla foods, to encourage combining many ingredients into one.</Description>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 	  <Nullable>enable</Nullable>

--- a/MuckFoods/Plugin.cs
+++ b/MuckFoods/Plugin.cs
@@ -4,7 +4,7 @@ using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
 
-[BepInPlugin("MuckFoods.MichMcb", "Muck Foods", "1.4.0")]
+[BepInPlugin("MuckFoods.MichMcb", "Muck Foods", "1.5.0")]
 public class Plugin : BaseUnityPlugin
 {
 	public static ManualLogSource Log = null!;

--- a/MuckFoods/manifest.json
+++ b/MuckFoods/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "MuckFoods",
-	"version_number": "1.4.0",
+	"version_number": "1.5.0",
 	"website_url": "https://github.com/Michmcb/MuckMods",
 	"description": "Adds a wide variety of foods which can be cooked by combining various existing ingredients in a Cauldron. This also decreases the effectiveness of some vanilla foods, to encourage combining many ingredients into one.",
 	"dependencies": ["BepInEx-BepInExPack_Muck-5.4.1101"]

--- a/MuckSaveGame/BaseGameSaveDataManager.cs
+++ b/MuckSaveGame/BaseGameSaveDataManager.cs
@@ -404,7 +404,7 @@
 		}
 		private void LoadLocalPlayer(SavedPlayer playerData)
 		{
-			InventoryItem[] allScriptableItems = ItemManager.Instance.allScriptableItems;
+			Dictionary<int, InventoryItem> allItems = ItemManager.Instance.allItems;
 
 			var bind = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
@@ -475,14 +475,14 @@
 				var itemId = playerData.Armor[i];
 				if (itemId != -1)
 				{
-					if (itemId < allScriptableItems.Length)
+					if (allItems.TryGetValue(itemId, out var item))
 					{
-						InventoryUI.Instance.AddArmor(allScriptableItems[itemId]);
+						InventoryUI.Instance.AddArmor(item);
 						PlayerStatus.Instance.UpdateArmor(i, itemId);
 					}
 					else
 					{
-						Plugin.Log.LogError(string.Concat("Error loading Player armor: Item ID is ", itemId, " but the maximum valid Item ID is ", allScriptableItems.Length, ". Skipping"));
+						Plugin.Log.LogError(string.Concat("Error loading Player armor: Item ID is ", itemId, " which was not found. Skipping"));
 					}
 				}
 			}
@@ -493,26 +493,26 @@
 				var invItem = playerData.Inventory[i];
 				if (invItem.Amount != 0)
 				{
-					if (invItem.ItemId < allScriptableItems.Length)
+					if (allItems.TryGetValue(invItem.ItemId, out var item))
 					{
-						InventoryUI.Instance.cells[i].ForceAddItem(allScriptableItems[invItem.ItemId], invItem.Amount);
+						InventoryUI.Instance.cells[i].ForceAddItem(item, invItem.Amount);
 					}
 					else
 					{
-						Plugin.Log.LogError(string.Concat("Error loading Player inventory: Item ID is ", invItem.ItemId, " but the maximum valid Item ID is ", allScriptableItems.Length, ". Skipping"));
+						Plugin.Log.LogError(string.Concat("Error loading Player inventory: Item ID is ", invItem.ItemId, " which was not found. Skipping"));
 					}
 				}
 			}
 
 			if (playerData.Arrows.Amount != 0)
 			{
-				if (playerData.Arrows.ItemId < allScriptableItems.Length)
+				if (allItems.TryGetValue(playerData.Arrows.ItemId, out var item))
 				{
-					InventoryUI.Instance.arrows.ForceAddItem(allScriptableItems[playerData.Arrows.ItemId], playerData.Arrows.Amount);
+					InventoryUI.Instance.arrows.ForceAddItem(item, playerData.Arrows.Amount);
 				}
 				else
 				{
-					Plugin.Log.LogError(string.Concat("Error loading arrows: Item ID is ", playerData.Arrows.ItemId, " but the maximum valid Item ID is ", allScriptableItems.Length, ". Skipping"));
+					Plugin.Log.LogError(string.Concat("Error loading arrows: Item ID is ", playerData.Arrows.ItemId, " which was not found. Skipping"));
 				}
 			}
 

--- a/MuckSaveGame/CHANGELOG.md
+++ b/MuckSaveGame/CHANGELOG.md
@@ -15,3 +15,6 @@
 
 # v0.7.0
 - More checks to try and prevent errors on saving game
+
+# v0.8.0
+- Mods that don't add their items to allScriptableItems and instead just add items to allItems are saved and loaded correctly

--- a/MuckSaveGame/MuckSaveGame.csproj
+++ b/MuckSaveGame/MuckSaveGame.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MuckSaveGame</AssemblyName>
     <Description>This mod adds saving your game to Muck. It is basically, a fork and update of flarfo's fantastic SaveUtility mod. This can automatically migrate saves from SaveUtility.</Description>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 	  <Nullable>enable</Nullable>

--- a/MuckSaveGame/Network/ClientMethods.cs
+++ b/MuckSaveGame/Network/ClientMethods.cs
@@ -164,7 +164,7 @@
 		{
 			Plugin.Log.LogInfo("Inventory Received!");
 
-			InventoryItem[] allScriptableItems = ItemManager.Instance.allScriptableItems;
+			var allItems = ItemManager.Instance.allItems;
 
 			int count = 0;
 
@@ -173,9 +173,9 @@
 				int id = _packet.ReadShort(true);
 				int amount = _packet.ReadShort(true);
 
-				if (id != -1)
+				if (id != -1 && allItems.TryGetValue(id, out var item))
 				{
-					InventoryUI.Instance.cells[count].ForceAddItem(allScriptableItems[id], amount);
+					InventoryUI.Instance.cells[count].ForceAddItem(item, amount);
 				}
 
 				count++;
@@ -258,16 +258,16 @@
 		{
 			Plugin.Log.LogInfo("Armor Received!");
 
-			InventoryItem[] allScriptableItems = ItemManager.Instance.allScriptableItems;
+			Dictionary<int, InventoryItem> allItems = ItemManager.Instance.allItems;
 
 			OtherInput.Instance.ToggleInventory(OtherInput.CraftingState.Inventory);
 			for (int i = 0; i < 4; i++)
 			{
 				short id = _packet.ReadShort(true);
 
-				if (id != -1)
+				if (id != -1 && allItems.TryGetValue(id, out var item))
 				{
-					InventoryUI.Instance.AddArmor(allScriptableItems[id]);
+					InventoryUI.Instance.AddArmor(item);
 					PlayerStatus.Instance.UpdateArmor(i, id);
 				}
 			}
@@ -276,9 +276,9 @@
 			short arrowId = _packet.ReadShort(true);
 			int arrowAmount = _packet.ReadInt(true);
 
-			if (arrowId != -1)
+			if (arrowId != -1 && allItems.TryGetValue(arrowId, out var arrowItem))
 			{
-				InventoryUI.Instance.arrows.ForceAddItem(allScriptableItems[arrowId], arrowAmount);
+				InventoryUI.Instance.arrows.ForceAddItem(arrowItem, arrowAmount);
 			}
 		}
 		private static void ReceiveTime(Packet _packet)

--- a/MuckSaveGame/Plugin.cs
+++ b/MuckSaveGame/Plugin.cs
@@ -10,7 +10,7 @@
 	using System.Reflection;
 	using System.Xml;
 	using UnityEngine;
-	[BepInPlugin("MuckSaveGame.MichMcb", "MuckSaveGame", "0.7.0")]
+	[BepInPlugin("MuckSaveGame.MichMcb", "MuckSaveGame", "0.8.0")]
 	[BepInIncompatibility("flarfo.saveutility")]
 	public class Plugin : BaseUnityPlugin
 	{

--- a/MuckSaveGame/manifest.json
+++ b/MuckSaveGame/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "MuckSaveGame",
-	"version_number": "0.7.0",
+	"version_number": "0.8.0",
 	"website_url": "https://github.com/Michmcb/MuckMods",
 	"description": "This mod adds saving your game to Muck. It is basically, a fork and update of flarfo's fantastic SaveUtility mod. This can automatically migrate saves from SaveUtility.",
 	"dependencies": ["BepInEx-BepInExPack_Muck-5.4.1101"]


### PR DESCRIPTION
…ly).

- ObamiumStuff for example did not add its items to allScriptableItems, only to allItems. So, we stopped relying on the former, as that caused problems.
- All mods that added items were affected by this (Arrows/Charcoal/Foods) as well as MuckSaveGame.